### PR TITLE
chore: drop placeholder switch platform

### DIFF
--- a/custom_components/ingresso/__init__.py
+++ b/custom_components/ingresso/__init__.py
@@ -13,8 +13,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .api import IngressoApiClient
 from .const import CONF_CITY_ID, CONF_CITY_NAME, CONF_PARTNERSHIP, CONF_THEATER, DOMAIN
 
-# Add SWITCH to platforms
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ingresso/manifest.json
+++ b/custom_components/ingresso/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://github.com/hudsonbrendon/HA-ingresso.com",
   "homekit": {},
   "iot_class": "cloud_polling",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "requirements": [],
   "ssdp": [],
   "zeroconf": [],


### PR DESCRIPTION
O switch que entrou no #69 era scaffolding do blueprint (`turn_on`/`turn_off` são no-ops) e criaria uma entidade inútil pro usuário. Remove `Platform.SWITCH` do `PLATFORMS`; o módulo fica pra evolução futura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)