### PR TITLE
fix: sensor SCAN_INTERVAL 30s → 30min

### DIFF
--- a/custom_components/ingresso/manifest.json
+++ b/custom_components/ingresso/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://github.com/hudsonbrendon/HA-ingresso.com",
   "homekit": {},
   "iot_class": "cloud_polling",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "requirements": [],
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/ingresso/sensor.py
+++ b/custom_components/ingresso/sensor.py
@@ -1,6 +1,7 @@
 """Support for Ingresso.com sensors."""
 
 import logging
+from datetime import timedelta
 from typing import Any, Dict, Optional
 
 import voluptuous as vol
@@ -27,6 +28,10 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Movie listings change a few times a day; the default 30s platform poll
+# hammers a slow API (each request can take up to the 30s timeout).
+SCAN_INTERVAL = timedelta(minutes=30)
 
 # Service constants
 SERVICE_GET_MOVIES = "get_movies"


### PR DESCRIPTION
O polling default de plataforma (30s) martela uma API lenta (request pode levar os 30s de timeout inteiros), gerando `Updating ingresso sensor took longer than the scheduled update interval 0:00:30` e timeouts em produção. Filmes em cartaz mudam poucas vezes ao dia — 30 minutos resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)